### PR TITLE
Add abstractions for request handling of endpoints `/api/v1/status` & `/api/v1/migrations` with `next-connect`

### DIFF
--- a/infra/errors.js
+++ b/infra/errors.js
@@ -17,3 +17,21 @@ export class InternalServerError extends Error {
     };
   }
 }
+
+export class MethodNotAllowedError extends Error {
+  constructor() {
+    super("Método não permitido.");
+    this.name = "MethodNotAllowedError";
+    this.action = "Consulte a documentação.";
+    this.statusCode = 405;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "16.4.5",
         "dotenv-expand": "11.0.6",
         "next": "14.2.5",
+        "next-connect": "1.0.0",
         "node-pg-migrate": "7.6.1",
         "pg": "8.12.0",
         "react": "18.3.1",
@@ -2071,6 +2072,12 @@
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8753,6 +8760,19 @@
         }
       }
     },
+    "node_modules/next-connect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-connect/-/next-connect-1.0.0.tgz",
+      "integrity": "sha512-FeLURm9MdvzY1SDUGE74tk66mukSqL6MAzxajW7Gqh6DZKBZLrXmXnGWtHJZXkfvoi+V/DUe9Hhtfkl4+nTlYA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tsconfig/node16": "^1.0.3",
+        "regexparam": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9866,6 +9886,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexparam": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-2.0.2.tgz",
+      "integrity": "sha512-A1PeDEYMrkLrfyOwv2jwihXbo9qxdGD3atBYQA9JJgreAx8/7rC6IUkWOw2NQlOxLp2wL0ifQbh1HuidDfYA6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "dotenv": "16.4.5",
     "dotenv-expand": "11.0.6",
     "next": "14.2.5",
+    "next-connect": "1.0.0",
     "node-pg-migrate": "7.6.1",
     "pg": "8.12.0",
     "react": "18.3.1",

--- a/pages/api/v1/status/index.js
+++ b/pages/api/v1/status/index.js
@@ -1,44 +1,49 @@
+import { createRouter } from "next-connect";
 import database from "infra/database.js";
-import { InternalServerError } from "infra/errors";
+import { InternalServerError, MethodNotAllowedError } from "infra/errors";
 
-async function status(req, res) {
-  try {
-    const updated_at = new Date().toISOString();
+const router = createRouter();
 
-    let qryRes = await database.query("SHOW server_version;");
-    const version = qryRes.rows[0].server_version;
+router.get(async (req, res) => {
+  const updated_at = new Date().toISOString();
 
-    qryRes = await database.query("SHOW max_connections;");
-    const max_connections = parseInt(qryRes.rows[0].max_connections);
+  let qryRes = await database.query("SHOW server_version;");
+  const version = qryRes.rows[0].server_version;
 
-    qryRes = await database.query({
-      text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
-      values: [process.env.POSTGRES_DB],
-    });
-    const opened_connections = qryRes.rows[0].count;
+  qryRes = await database.query("SHOW max_connections;");
+  const max_connections = parseInt(qryRes.rows[0].max_connections);
 
-    const status = {
-      updated_at,
-      dependencies: {
-        database: {
-          version,
-          max_connections,
-          opened_connections,
-        },
+  qryRes = await database.query({
+    text: "SELECT count(*)::int FROM pg_stat_activity WHERE datname = $1;",
+    values: [process.env.POSTGRES_DB],
+  });
+  const opened_connections = qryRes.rows[0].count;
+
+  const status = {
+    updated_at,
+    dependencies: {
+      database: {
+        version,
+        max_connections,
+        opened_connections,
       },
-    };
+    },
+  };
 
-    res.status(200).json(status);
-  } catch (err) {
+  res.status(200).json(status);
+});
+
+export default router.handler({
+  onNoMatch: (req, res) => {
+    const publicError = new MethodNotAllowedError();
+    return res.status(publicError.statusCode).json(publicError);
+  },
+  onError: (err, req, res) => {
     const publicError = new InternalServerError({
       cause: err,
     });
-
-    console.error("\n Erro dentro do catch do controller: ");
+    console.error("\n Erro dentro do catch do next-connect:");
     console.error(publicError);
-
-    res.status(500).json(publicError);
-  }
-}
-
-export default status;
+    res.status(publicError.statusCode).json(publicError);
+  },
+});

--- a/tests/integration/api/v1/migrations/post.test.js
+++ b/tests/integration/api/v1/migrations/post.test.js
@@ -18,7 +18,7 @@ describe("POST /api/v1/migrations", () => {
       expect(body.length).toBeGreaterThan(0);
     });
 
-    test("Run migrations after already applied", async () => {
+    test("Run migrations after they have been applied", async () => {
       const res = await fetch("http://localhost:3000/api/v1/migrations", {
         method: "POST",
       });

--- a/tests/integration/api/v1/status/post.test.js
+++ b/tests/integration/api/v1/status/post.test.js
@@ -1,0 +1,20 @@
+import { MethodNotAllowedError } from "infra/errors";
+import orchestrator from "tests/orchestrator";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+});
+
+describe("POST /api/v1/status", () => {
+  describe("Anonymous user", () => {
+    test("Retrieve current system status", async () => {
+      const res = await fetch("http://localhost:3000/api/v1/status", {
+        method: "POST",
+      });
+      expect(res.status).toBe(405);
+
+      const body = await res.json();
+      expect(typeof body).toEqual(typeof new MethodNotAllowedError());
+    });
+  });
+});


### PR DESCRIPTION
Add abstractions to handle (a) methods that are not allowed and (b) internal server errors.